### PR TITLE
Fixed typo in FSM project

### DIFF
--- a/5. Software Onboarding/5.07 Finite State Machine [PROJECT].md
+++ b/5. Software Onboarding/5.07 Finite State Machine [PROJECT].md
@@ -2,7 +2,7 @@
 For this project you will be creating a simulated model of a simple flight computer. This model should be able to change operation modes based on the external inputs it receives. 
 
 ## Background 
-A finite state machine (FSM) is a mathematical model used to represent a system the can be in exactly one state out of a finite number of possible states. This can help simplify a complex system by dividing its behaviour discrete states and actions that respond to specific stimuli.  
+A finite state machine (FSM) is a mathematical model used to represent a system the can be in exactly one state out of a finite number of possible states. This can help simplify a complex system by dividing its behaviour into discrete states and actions that respond to specific stimuli.  
 
 ## Task Requirements 
 - The FSM should consist of the following states:


### PR DESCRIPTION
The initial FSM information in the background section stated, "[...] dividing its behaviour discrete states [...]" which has been updated to "[...] dividing its behaviour *into* discrete states [...]"