### PR TITLE
Added first draft of telemetry validation project

### DIFF
--- a/5. Software Onboarding/5.09 Telemetry Validation [PROJECT].md
+++ b/5. Software Onboarding/5.09 Telemetry Validation [PROJECT].md
@@ -1,0 +1,81 @@
+# Telemetry Validation
+
+Design, implement and validate a protocol for communication between an embedded system and a computer, ensuring robust code such that the implementation does not fail when several errors may occur.
+
+## Background 
+
+A telemetry link, in terms of a CubeSat is the connection between the CubeSat and the ground. Over this telemetry link are the sensor data and measurements transmitted. This link must be robust as there are many sources of noise and error in space. Should the link fail, any data that relies on this link will be lost. For an operational CubeSat, this can be a total failure point as without communication (assuming the connection is not re-established), any sensor readings or critical data would not be able to reach the ground station and the CubeSat would be reduced to space junk.
+
+To prevent total failure in the telemetry link due to noise and erroneous data, any data sent or received must be sanitised or packaged so that metadata regarding the relative 'health' of the data is included. This metadata and the communication protocol must be decided beforehand and thoroughly tested to ensure its robust nature. The document that outlines all decisions and information relating to communication or the telemetry link is the interface control document (ICD).
+
+Often, the ICD describes information regarding packet structure for the communication, where a packet is a structured block of data that is sent between two devices. It is important to create packets as this ensures that each device understands what is being received, allowing the device to interpret the received data. A stream of raw data can be used without packets, but this lacks the flexibility required when dealing with multiple sources of information and differing types of data.
+
+## Prerequisites
+
+- Basic C and Python knowledge. Information relating to C programming can be found in [5.01 Intro to C Programming \[RESOURCE\].md](https://github.com/PerthAerospaceStudentTeam/Onboarding/blob/main/5.%20Software%20Onboarding/5.01%20Intro%20to%20C%20Programming%20%5BRESOURCE%5D.md)
+
+- [5.02 Intro to Git \[RESOURCE\].md](https://github.com/PerthAerospaceStudentTeam/Onboarding/blob/main/5.%20Software%20Onboarding/5.02%20Intro%20to%20Git%20%5BRESOURCE%5D.md)
+
+- [5.03 Programming the STM32 \[RESOURCE\].md](https://github.com/PerthAerospaceStudentTeam/Onboarding/blob/main/5.%20Software%20Onboarding/5.03%20Programming%20the%20STM32%20%5BRESOURCE%5D.md)
+
+- [5.04 Serial Communication \[RESOURCE\].md](https://github.com/PerthAerospaceStudentTeam/Onboarding/blob/main/5.%20Software%20Onboarding/5.04%20Serial%20Communication%20%5BRESOURCE%5D.md)
+
+## Project Requirements
+
+- Any structured packets should be of minimal length in terms of bytes. This ensures that if one packet is lost, the data loss is minimal. No single packet can be greater than 256 bytes.
+
+- There must exist a way of verifying if the packet data is correct which is included in the packet.
+
+- Packets of variable length must be accepted.
+
+## Project Deliverables
+
+- A maximum one-page ICD which defines (at minimum):
+    - the types of packets
+    - packet structures (in terms of bytes)
+    - any properties relating to the communication itself (like baud rate, etc.)
+
+- A transmitter implemented using an STM32 Nucleo Board in C that reads simulated sensor values and transmits the structured packets to the receiver.
+
+- A receiver that is primarily a python application which:
+    - reads the serial stream
+    - validates the packets
+    - logs the valid data
+    - handles invalid data
+
+- A report that documents what the system does when it encounters faulty data. The faulty data must also be simulated by introducing errors in the transmission. Faults may include, but are not limited to:
+    - packet data corruption mid-transmission
+    - dropped packets
+    - packets arriving out of sync
+    - unexpected end of transmission from the transmitter
+    
+    The report must contrast the expected behaviour of the fault (as defined by the ICD) with the actual behaviour of the program when the fault is introduced.
+
+> [!NOTE]
+> If working in pairs, one person will work with the transmitter and the other with the receiver. Both people will have to work on the ICD and agree on the packet structure and implementation. No one person may change the ICD without consulting the other.
+ 
+## Stretch Goals
+
+- Implement an acknowledge and retry scheme so the receiver can request a resend of any dropped packets.
+
+- Add a telemetry health watchdog that generates an alert if no valid packet is received within a given timeout.
+
+- Log the received telemetry data in a CSV format and write a program to allow visualisation of that data.
+
+- Implement a way of recovering information from a corrupted packet given the implemented error correction or verification method.
+
+## Resources 
+
+- [UART Serial Communication - SparkFun](https://learn.sparkfun.com/tutorials/serial-communication)
+
+- [Python pyserial Documentation](https://pyserial.readthedocs.io/en/latest/)
+
+## Tips
+
+- Define the packet framing scheme carefully before anything else as it is very difficult to modify later.
+
+- Use a start byte sequence to allow for easy identification of packets.
+
+- Test the receiver against manually created byte arrays before connecting it to the hardware. Also create unit tests to test the logic independent of the hardware.
+
+- Design for fault tolerance from the start, ensuring the receiver does not crash when given faulty input. Log the information whenever a fault occurs.


### PR DESCRIPTION
This is the first draft of the telemetry validation onboarding project. Any feedback would be greatly appreciated. 

Fake data needs to be created still that can be used for the transmission

I had a few issues/concerns with the project:
  - One page maximum may not be enough for the ICD
  - Perhaps a maximum page limit for the report that outlines the fault handling should be set
  - The types of packets or sensors should probably be defined for the project. For example: the CubeSat needs a three-axis accelerometer that has acceleration data on x, y and z axes. Create a packet type for this sensor, etc.
  - Perhaps further work can include data spanning multiple packets. (ie. packet 1 of 2 or something)
  - I set a maximum size of 256 bytes as this would be best practice but this may be changed later.