### PR TITLE
Added example sensor data for packets

### DIFF
--- a/5. Software Onboarding/5.09 Telemetry Validation [PROJECT].md
+++ b/5. Software Onboarding/5.09 Telemetry Validation [PROJECT].md
@@ -4,7 +4,7 @@ Design, implement and validate a protocol for communication between an embedded 
 
 ## Background 
 
-A telemetry link, in terms of a CubeSat is the connection between the CubeSat and the ground. Over this telemetry link are the sensor data and measurements transmitted. This link must be robust as there are many sources of noise and error in space. Should the link fail, any data that relies on this link will be lost. For an operational CubeSat, this can be a total failure point as without communication (assuming the connection is not re-established), any sensor readings or critical data would not be able to reach the ground station and the CubeSat would be reduced to space junk.
+A telemetry link, in terms of a CubeSat is the connection between the CubeSat and the ground. Over this telemetry link the sensor data and measurements are transmitted. This link must be robust as there are many sources of noise and error in space which can corrupt the transmitted data. Should the link fail, any data that relies on this link will be lost. Total communication loss is a major failure point for a CubeSat. If the link cannot be re-established, any data from the onboard sensors and payload would be unable to reach the ground station, rendering the CubeSat useless.
 
 To prevent total failure in the telemetry link due to noise and erroneous data, any data sent or received must be sanitised or packaged so that metadata regarding the relative 'health' of the data is included. This metadata and the communication protocol must be decided beforehand and thoroughly tested to ensure its robust nature. The document that outlines all decisions and information relating to communication or the telemetry link is the interface control document (ICD).
 
@@ -28,9 +28,11 @@ Often, the ICD describes information regarding packet structure for the communic
 
 - Packets of variable length must be accepted.
 
+- Data spanning multiple packets must be accepted.
+
 ## Project Deliverables
 
-- A maximum one-page ICD which defines (at minimum):
+- An ICD which defines (at minimum):
     - the types of packets
     - packet structures (in terms of bytes)
     - any properties relating to the communication itself (like baud rate, etc.)
@@ -48,8 +50,11 @@ Often, the ICD describes information regarding packet structure for the communic
     - dropped packets
     - packets arriving out of sync
     - unexpected end of transmission from the transmitter
+    - ghost packets
     
     The report must contrast the expected behaviour of the fault (as defined by the ICD) with the actual behaviour of the program when the fault is introduced.
+
+    The report should be less than three pages in length but must not be more than five pages in length.
 
 > [!NOTE]
 > If working in pairs, one person will work with the transmitter and the other with the receiver. Both people will have to work on the ICD and agree on the packet structure and implementation. No one person may change the ICD without consulting the other.
@@ -69,6 +74,248 @@ Often, the ICD describes information regarding packet structure for the communic
 - [UART Serial Communication - SparkFun](https://learn.sparkfun.com/tutorials/serial-communication)
 
 - [Python pyserial Documentation](https://pyserial.readthedocs.io/en/latest/)
+
+- <details>
+    <summary>Click to reveal example GNSS sensor data</summary>
+    
+    ```
+    Time,Latitude,Longitude,Altitude
+    134016.00,-32.00615,115.89100,100.00
+    134047.00,-32.00592,115.89136,200.00
+    134052.00,-32.00932,115.89474,300.00
+    134103.00,-32.00967,115.89822,450.00
+    134136.00,-32.01197,115.90176,600.00
+    134190.00,-32.01422,115.90536,750.00
+    134202.00,-32.01342,115.90901,950.00
+    134225.00,-32.01457,115.91269,1050.00
+    134252.00,-32.01667,115.91639,1200.00
+    134305.00,-32.01572,115.92010,1300.00
+    134350.00,-32.01672,115.92383,1400.00
+    134365.00,-32.01967,115.92755,1500.00
+    134417.00,-32.02157,115.93127,1600.00
+    134442.00,-32.02042,115.93499,1650.00
+    134482.00,-32.02222,115.93870,1700.00
+    134488.00,-32.02197,115.94239,1900.00
+    134533.00,-32.02267,115.94608,2050.00
+    134565.00,-32.02232,115.94975,2200.00
+    134612.00,-32.02192,115.95341,2350.00
+    134667.00,-32.02347,115.95706,2550.00
+    134681.00,-32.02397,115.96069,2650.00
+    134713.00,-32.02342,115.96431,2800.00
+    134760.00,-32.02482,115.96792,2950.00
+    134820.00,-32.02317,115.97152,3000.00
+    134872.00,-32.02347,115.97510,3200.00
+    134909.00,-32.02172,115.97868,3300.00
+    134925.00,-32.02092,115.98224,3500.00
+    134976.00,-32.02107,115.98578,3650.00
+    135021.00,-32.02017,115.98932,3700.00
+    135074.00,-32.01922,115.99284,3750.00
+    135129.00,-32.01822,115.99635,3800.00
+    135159.00,-32.01917,115.99985,3950.00
+    135198.00,-32.02007,116.00333,4000.00
+    135218.00,-32.01992,116.00679,4100.00
+    135264.00,-32.02172,116.01023,4200.00
+    135283.00,-32.02047,116.01365,4400.00
+    135312.00,-32.01917,116.01704,4450.00
+    135356.00,-32.01682,116.02042,4600.00
+    135387.00,-32.01642,116.02376,4700.00
+    135423.00,-32.01597,116.02707,4850.00
+    135467.00,-32.01347,116.03036,4950.00
+    135519.00,-32.01192,116.03361,5150.00
+    135577.00,-32.01132,116.03682,5300.00
+    135609.00,-32.01267,116.04000,5350.00
+    135663.00,-32.01297,116.04314,5400.00
+    135674.00,-32.01122,116.04624,5600.00
+    135733.00,-32.01242,116.04930,5750.00
+    135780.00,-32.01157,116.05233,5950.00
+    135793.00,-32.01267,116.05533,6000.00
+    135805.00,-32.01272,116.05829,6100.00
+    135829.00,-32.01072,116.06122,6300.00
+    ```
+
+</details>
+
+- <details>
+    <summary>Click to reveal example Barometer data</summary>
+
+    ```
+    Pressure,Temperature
+    101000,25
+    100898,24
+    100094,22
+    99456,21
+    98325,21
+    98144,20
+    96520,17
+    95367,17
+    94615,15
+    94449,15
+    93757,14
+    91848,11
+    90150,11
+    88983,11
+    87865,10
+    87482,8
+    85589,8
+    83908,6
+    82273,3
+    82079,2
+    80451,-1
+    78807,-1
+    77753,-4
+    77228,-7
+    75388,-7
+    73603,-9
+    72009,-11
+    70093,-11
+    68186,-13
+    66487,-13
+    66214,-13
+    65991,-15
+    65808,-16
+    64700,-19
+    63333,-19
+    62827,-22
+    62251,-23
+    61926,-23
+    60427,-25
+    60313,-27
+    60182,-28
+    59956,-28
+    59418,-29
+    57816,-31
+    57383,-32
+    57170,-35
+    56179,-37
+    55018,-38
+    54556,-40
+    53299,-41
+    52466,-41
+    ```
+
+</details>
+
+- <details>
+    <summary>Click to reveal example IMU data</summary>
+
+    ```
+    Acceleration,,,Angular Velocity,,,Magnetometer,,
+    X,Y,Z,X,Y,Z,X,Y,Z
+    4229,1466,8290,158,-2,-51,-99,188,241
+    4330,1324,8299,171,-11,-49,-106,183,241
+    4422,1231,8294,175,-14,-46,-87,177,240
+    4448,1128,8303,179,-16,-51,-96,172,239
+    4584,1039,8301,183,-23,-55,-91,168,238
+    4722,1013,8355,196,-28,-51,-77,163,239
+    4854,858,8367,208,-32,-55,-74,160,238
+    4898,746,8417,215,-33,-59,-80,155,238
+    4941,601,8425,229,-41,-57,-68,152,237
+    4985,587,8452,234,-48,-54,-52,149,235
+    4993,556,8505,241,-49,-52,-54,146,236
+    5094,541,8551,249,-52,-46,-45,142,238
+    5112,529,8534,253,-53,-41,-39,136,236
+    5185,364,8570,256,-56,-36,-21,133,238
+    5358,314,8581,270,-64,-37,-11,130,240
+    5443,258,8570,281,-65,-33,-11,125,241
+    5561,86,8578,293,-70,-38,-7,120,239
+    5640,66,8618,301,-79,-36,-8,117,237
+    5716,-108,8645,312,-87,-39,-3,114,239
+    5777,-166,8676,321,-95,-39,15,109,237
+    5895,-286,8668,329,-100,-36,28,106,235
+    5975,-423,8722,340,-103,-35,44,103,237
+    6037,-566,8777,345,-109,-30,45,97,236
+    6131,-715,8822,350,-111,-33,64,91,237
+    6274,-848,8881,356,-114,-36,59,86,238
+    6370,-857,8887,361,-121,-36,72,83,236
+    6400,-961,8880,375,-130,-32,89,78,237
+    6436,-1000,8874,382,-137,-34,96,75,238
+    6448,-1140,8906,393,-142,-32,116,69,239
+    6502,-1232,8938,401,-145,-26,116,65,241
+    6606,-1270,8985,411,-148,-26,108,62,242
+    6648,-1407,9008,423,-153,-24,118,57,243
+    6812,-1451,9068,426,-155,-25,111,53,244
+    6880,-1488,9078,431,-160,-21,107,47,244
+    7006,-1586,9101,445,-163,-19,121,41,242
+    7014,-1708,9149,456,-170,-19,116,38,244
+    7036,-1818,9175,460,-173,-13,130,33,242
+    7196,-1876,9179,469,-177,-18,135,28,243
+    7336,-1919,9201,481,-179,-14,137,25,241
+    7407,-2056,9197,487,-185,-8,137,22,242
+    7551,-2104,9205,490,-191,-5,148,16,242
+    7655,-2155,9250,504,-193,-1,167,12,244
+    7725,-2285,9253,517,-201,0,178,9,245
+    7795,-2412,9239,523,-202,1,172,6,245
+    7857,-2430,9261,527,-204,5,169,2,246
+    7871,-2569,9247,532,-209,6,170,-3,244
+    7963,-2707,9264,535,-217,9,170,-8,246
+    8091,-2878,9282,541,-226,15,181,-12,244
+    8222,-2896,9286,546,-228,17,193,-16,245
+    8231,-3057,9343,558,-232,16,209,-22,246
+    8237,-3127,9338,570,-241,13,224,-27,246
+    8404,-3263,9381,583,-247,15,225,-31,248
+    ```
+
+</details>
+
+- <details>
+    <summary>Click to reveal example Battery Monitor data</summary>
+
+    ```
+    Time,Percentage,Status
+    12:00,100,OK
+    12:05,99,OK
+    12:10,97,OK
+    12:15,96,OK
+    12:20,95,OK
+    12:25,93,OK
+    12:30,93,OK
+    12:35,92,OK
+    12:40,90,OK
+    12:45,88,OK
+    12:50,87,OK
+    12:55,86,OK
+    13:00,85,OK
+    13:05,83,OK
+    13:10,83,OK
+    13:15,80,OK
+    13:20,79,OK
+    13:25,78,OK
+    13:30,77,OK
+    13:35,76,OK
+    13:40,75,OK
+    13:45,74,OK
+    13:50,73,OK
+    13:55,70,OK
+    14:00,69,OK
+    14:05,67,OK
+    14:10,66,OK
+    14:15,64,OK
+    14:20,63,OK
+    14:25,62,OK
+    14:30,61,OK
+    14:35,60,OK
+    14:40,58,OK
+    14:45,57,OK
+    14:50,56,OK
+    14:55,54,OK
+    15:00,51,OK
+    15:05,50,OK
+    15:10,49,OK
+    15:15,0,ERROR
+    15:20,0,ERROR
+    15:25,0,ERROR
+    15:30,0,ERROR
+    15:35,0,ERROR
+    15:40,0,ERROR
+    15:45,0,ERROR
+    15:50,0,ERROR
+    15:55,0,ERROR
+    16:00,0,ERROR
+    16:05,0,ERROR
+    16:10,0,ERROR
+    ```
+
+</details>
 
 ## Tips
 


### PR DESCRIPTION
Some example sensor data was embedded into the telemetry onboarding project. Some paragraphs were rephrased for easier interpretation and added a requirement to allow for data spanning multiple packets. 

Might need to add a sample image like the PAST logo as an example for the data spanning multiple packets.