### PR TITLE
Updated STM32CubeIDE version requirements

### DIFF
--- a/5. Software Onboarding/5.03 Programming the STM32 [RESOURCE].md
+++ b/5. Software Onboarding/5.03 Programming the STM32 [RESOURCE].md
@@ -6,7 +6,7 @@ The STM32 family of microcontrollers is primarily what we use as the flight comp
 
 ## First Project 
 This will walk you through the steps required to create a simple STM32 Project that blinks one of the onboard LEDs. A more detailed tutorial that includes the setup and use of additional hardware features can be found on the discord in the channel [onboarding-resources](https://discord.com/channels/1326364517881352272/1337048190041587826).  
-1. Download and install STM32CubeIDE: https://www.st.com/en/development-tools/stm32cubeide.html
+1. Download and install STM32CubeIDE. Ensure that you install version **1.19.0**. The install link can be found here: https://www.st.com/en/development-tools/stm32cubeide.html
 2. Once the install process has finished, launch the software and create a new STM32 Project. You may need to wait a few minutes while it downloads additional files.
 
 ![416148429-8c01b131-5703-4244-b378-b4c4ad4bd95f](https://github.com/user-attachments/assets/c74385df-d6e5-4fb9-97da-23ff34e397a1)

--- a/5. Software Onboarding/5.03 Programming the STM32 [RESOURCE].md
+++ b/5. Software Onboarding/5.03 Programming the STM32 [RESOURCE].md
@@ -5,8 +5,12 @@ The STM32 family of microcontrollers is primarily what we use as the flight comp
 - [Getting Started with STM32 and Nucleo Part 1](https://youtu.be/hyZS2p1tW-g?si=03hjzHC9kvGC5h2D) this video is similar to the following tutorial and can help provide additional context. Be aware that they are using a different nucleo board so the pin configuration will differ. 
 
 ## First Project 
-This will walk you through the steps required to create a simple STM32 Project that blinks one of the onboard LEDs. A more detailed tutorial that includes the setup and use of additional hardware features can be found on the discord in the channel [onboarding-resources](https://discord.com/channels/1326364517881352272/1337048190041587826).  
-1. Download and install STM32CubeIDE. Ensure that you install version **1.19.0**. The install link can be found here: https://www.st.com/en/development-tools/stm32cubeide.html
+This will walk you through the steps required to create a simple STM32 Project that blinks one of the onboard LEDs. A more detailed tutorial that includes the setup and use of additional hardware features can be found on the discord in the channel [onboarding-resources](https://discord.com/channels/1326364517881352272/1337048190041587826).
+
+> [!CAUTION]
+> Ensure that you install version **1.19.0** of the STM32CubeIDE.
+
+1. Download and install STM32CubeIDE. The install link can be found here: https://www.st.com/en/development-tools/stm32cubeide.html
 2. Once the install process has finished, launch the software and create a new STM32 Project. You may need to wait a few minutes while it downloads additional files.
 
 ![416148429-8c01b131-5703-4244-b378-b4c4ad4bd95f](https://github.com/user-attachments/assets/c74385df-d6e5-4fb9-97da-23ff34e397a1)


### PR DESCRIPTION
The version requirement of 1.19.0 was included in the tutorial for the STM32CubeIDE as major overhauls in version 2.0.0 and onwards break the tutorial. Perhaps this should be revisited later.